### PR TITLE
Add unit tests for org.apache.hadoop.hbase.util.ByteRangeUtils and Classes

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class TestByteRangeUtils {
+
+  @Test
+  public void testNumEqualPrefixBytes() {
+    Assert.assertEquals(0, ByteRangeUtils.numEqualPrefixBytes(
+            new SimpleByteRange(new byte[]{1, 2, 3}),
+            new SimpleByteRange(new byte[]{4, 5, 6}), 1));
+    Assert.assertEquals(2, ByteRangeUtils.numEqualPrefixBytes(
+            new SimpleByteRange(new byte[]{1, 2, 3}),
+            new SimpleByteRange(new byte[]{0, 1, 2}), 1));
+  }
+
+  @Test
+  public void testCopyToNewArrays() {
+    Assert.assertEquals(new ArrayList<>(), ByteRangeUtils.copyToNewArrays(null));
+    Assert.assertArrayEquals(new byte[]{1, 2, 3},
+            ByteRangeUtils.copyToNewArrays(new ArrayList<>(Arrays.asList(
+                    new SimpleByteRange(new byte[]{1, 2, 3}),
+                    new SimpleByteRange(new byte[]{4, 5, 6})))).get(0));
+    Assert.assertArrayEquals(new byte[]{4, 5, 6},
+            ByteRangeUtils.copyToNewArrays(new ArrayList<>(Arrays.asList(
+                    new SimpleByteRange(new byte[]{1, 2, 3}),
+                    new SimpleByteRange(new byte[]{4, 5, 6})))).get(1));
+  }
+
+  @Test
+  public void testFromArrays() {
+    Assert.assertEquals(new ArrayList<>(), ByteRangeUtils.fromArrays(null));
+    Assert.assertEquals(new ArrayList<>(Arrays.asList(
+            new SimpleMutableByteRange(new byte[]{1, 2, 3}),
+            new SimpleMutableByteRange(new byte[]{4, 5, 6}))),
+            ByteRangeUtils.fromArrays(new ArrayList<>(
+                    Arrays.asList(new byte[]{1, 2, 3}, new byte[]{4, 5, 6}))));
+  }
+}

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestClasses.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestClasses.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestClasses {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testExtendedForName() throws ClassNotFoundException {
+    Assert.assertEquals(int.class, Classes.extendedForName("int"));
+    Assert.assertEquals(long.class, Classes.extendedForName("long"));
+    Assert.assertEquals(char.class, Classes.extendedForName("char"));
+    Assert.assertEquals(byte.class, Classes.extendedForName("byte"));
+    Assert.assertEquals(short.class, Classes.extendedForName("short"));
+    Assert.assertEquals(float.class, Classes.extendedForName("float"));
+    Assert.assertEquals(double.class, Classes.extendedForName("double"));
+    Assert.assertEquals(boolean.class, Classes.extendedForName("boolean"));
+
+    thrown.expect(ClassNotFoundException.class);
+    Classes.extendedForName("foo");
+  }
+
+  @Test
+  public void testStringify() {
+    Assert.assertEquals("", Classes.stringify(new Class[0]));
+    Assert.assertEquals("NULL", Classes.stringify(null));
+    Assert.assertEquals("java.lang.String,java.lang.Integer",
+            Classes.stringify(new Class[]{String.class, Integer.class}));
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.apache.hadoop.hbase.util.ByteRangeUtils` and `Classes` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.